### PR TITLE
Add refactor changes to split db operations into database.py

### DIFF
--- a/myblogapp/app.py
+++ b/myblogapp/app.py
@@ -1,14 +1,8 @@
 from flask import Flask, request, jsonify, render_template
-import sqlite3
-from datetime import datetime
 import bloglog as bloglog
+import database as db
 
 app = Flask(__name__)
-db_name = 'myblog.db'
-
-def init_db():
-    
-    pass
 
 def write_log(response, msg):
     bloglogger = bloglog.BlogLog()
@@ -22,177 +16,101 @@ def index():
 @app.route('/authors', methods=['POST'])
 def create_author():
     data = request.get_json()
-    username = data.get('username')
-    email = data.get('email')
-    password = data.get('password')
-    bio = data.get('bio')
-    profile_picture = data.get('profile_picture')
-
-    with sqlite3.connect(db_name) as conn:
-        cursor = conn.cursor()
-        try:
-            cursor.execute('''
-                INSERT INTO Author (username, email, password, bio, profile_picture)
-                VALUES (?, ?, ?, ?, ?)
-            ''', (username, email, password, bio, profile_picture))
-            conn.commit()
-            user_id = cursor.lastrowid
-            write_log(201, "create_author")
-            return jsonify(user_id=user_id, username=username, email=email, bio=bio, profile_picture=profile_picture), 201
-        except sqlite3.IntegrityError as e:
-            write_log(400, "create author")
-            return jsonify(error=str(e)), 400
+    user_id = db.create_author(data.get('username'), data.get('email'), data.get('password'), data.get('bio'), data.get('profile_picture'))
+    if user_id:
+        write_log(201, "create_author")
+        return jsonify(user_id=user_id, **data), 201
+    else:
+        write_log(400, "create author")
+        return jsonify(error="Error creating new author"), 400
 
 @app.route('/authors/<int:user_id>', methods=['GET'])
 def get_author(user_id):
-    with sqlite3.connect(db_name) as conn:
-        cursor = conn.cursor()
-        cursor.execute('SELECT * FROM Author WHERE user_id=?', (user_id,))
-        author = cursor.fetchone()
-        if author:
-            write_log(200, "get_author({user_id})")
-            return jsonify(user_id=author[0], username=author[1], email=author[2], bio=author[4], profile_picture=author[5]), 200
-        else:
-            write_log(404, "get_author({user_id})")
-            return jsonify(error="Author not found"), 404
+    author = db.get_author(user_id)
+    if author:
+        write_log(200, f"get_author({user_id})")
+        return jsonify(user_id=author[0], username=author[1], email=author[2], bio=author[4], profile_picture=author[5]), 200
+    else:
+        write_log(404, f"get_author({user_id})")
+        return jsonify(error="Author not found"), 404
 
 @app.route('/authors/<int:user_id>', methods=['PUT'])
 def update_author(user_id):
     data = request.get_json()
-    username = data.get('username')
-    email = data.get('email')
-    bio = data.get('bio')
-    profile_picture = data.get('profile_picture')
-
-    with sqlite3.connect(db_name) as conn:
-        cursor = conn.cursor()
-        cursor.execute('''
-            UPDATE Author SET username=?, email=?, bio=?, profile_picture=?
-            WHERE user_id=?
-        ''', (username, email, bio, profile_picture, user_id))
-        conn.commit()
-        if cursor.rowcount:
-            write_log(200, "update_author({user_id})")
-            return jsonify(user_id=user_id, username=username, email=email, bio=bio, profile_picture=profile_picture), 200
-        else:
-            write_log(404, "update_author({user_id})")
-            return jsonify(error="Author not found"), 404
+    rowcount = db.update_author(user_id, data.get('username'), data.get('email'), data.get('bio'), data.get('profile_picture'))
+    if rowcount:
+        write_log(200, f"update_author({user_id})")
+        return jsonify(user_id=user_id, **data), 200
+    else:
+        write_log(404, f"update_author({user_id})")
+        return jsonify(error="Author not found"), 404
 
 @app.route('/authors/<int:user_id>', methods=['DELETE'])
 def delete_author(user_id):
-    with sqlite3.connect(db_name) as conn:
-        cursor = conn.cursor()
-        cursor.execute('DELETE FROM Author WHERE user_id=?', (user_id,))
-        conn.commit()
-        if cursor.rowcount:
-            write_log(200, "delete_author({user_id})")
-            return jsonify(message="Author deleted"), 200
-        else:
-            write_log(404, "delete_author({user_id})")
-            return jsonify(error="Author not found"), 404
+    rowcount = db.delete_author(user_id)
+    if rowcount:
+        write_log(200, f"delete_author({user_id})")
+        return jsonify(message="Author deleted"), 200
+    else:
+        write_log(404, f"delete_author({user_id})")
+        return jsonify(error="Author not found"), 404
 
 @app.route('/api/blogentries/', methods=['POST'])
 def create_blog_entry():
     data = request.get_json()
-    user_id = data.get('user_id')
-    title = data.get('title')
-    subtitle = data.get('subtitle')
-    blurb = data.get('blurb')
-    content = data.get('content')
-    is_published = data.get('is_published', False)
-    time_created = datetime.now()
-    time_updated = time_created
-
-    with sqlite3.connect(db_name) as conn:
-        cursor = conn.cursor()
-        cursor.execute('''
-            INSERT INTO BlogEntry (user_id, title, subtitle, blurb, content, time_created, time_updated, is_published)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        ''', (user_id, title, subtitle, blurb, content, time_created, time_updated, is_published))
-        conn.commit()
-        post_id = cursor.lastrowid
-        write_log(201, "create_blog_entry())")
-        return jsonify(post_id=post_id, user_id=user_id, title=title, subtitle=subtitle, blurb=blurb, content=content, is_published=is_published, time_created=time_created), 201
+    post_id, time_created = db.create_blog_entry(data.get('user_id'), data.get('title'), data.get('subtitle'), data.get('blurb'), data.get('content'), data.get('is_published', False))
+    write_log(201, "create_blog_entry()")
+    return jsonify(post_id=post_id, time_created=time_created, **data), 201
 
 @app.route('/api/blogentries/<int:post_id>', methods=['GET'])
 def get_blog_entry(post_id):
-    with sqlite3.connect(db_name) as conn:
-        cursor = conn.cursor()
-        cursor.execute('SELECT * FROM BlogEntry WHERE post_id=?', (post_id,))
-        entry = cursor.fetchone()
-        if entry:
-            write_log(200, "get_blog_entry({post_id}))")
-            return jsonify(post_id=entry[0], user_id=entry[1], title=entry[2], subtitle=entry[3], blurb=entry[4], content=entry[5], time_created=entry[6], time_updated=entry[7], is_published=entry[8]), 200
-        else:
-            write_log(404, "create_blog_entry({post_id}))")
-            return jsonify(error="Blog entry not found"), 404
-        
+    entry = db.get_blog_entry(post_id)
+    if entry:
+        write_log(200, f"get_blog_entry({post_id})")
+        return jsonify(post_id=entry[0], user_id=entry[1], title=entry[2], subtitle=entry[3], blurb=entry[4], content=entry[5], time_created=entry[6], time_updated=entry[7], is_published=entry[8]), 200
+    else:
+        write_log(404, f"get_blog_entry({post_id})")
+        return jsonify(error="Blog entry not found"), 404
+
 @app.route('/api/blogentries/all', methods=['GET'])
 def get_blog_entries():
-    with sqlite3.connect(db_name) as conn:
-        cursor = conn.cursor()
-        
-        # Query to get all blog entries
-        cursor.execute("SELECT * FROM BlogEntry")
-        rows = cursor.fetchall()
-        
-        # Convert the query result to a list of dictionaries
-        blog_entries = []
-        for row in rows:
-            blog_entry = {
-                'post_id': row[0],
-                'user_id': row[1],
-                'title': row[2],
-                'subtitle': row[3],
-                'blurb': row[4],
-                'content': row[5],
-                'time_created': row[6],
-                'time_updated': row[7],
-                'is_published': row[8]
-            }
-            blog_entries.append(blog_entry)
-        
-        # Return the data as a JSON response
-        write_log(999, "get_blog_entries()")
-        return jsonify(blog_entries)
+    rows = db.get_blog_entries()
+    blog_entries = [
+        {
+            'post_id': row[0],
+            'user_id': row[1],
+            'title': row[2],
+            'subtitle': row[3],
+            'blurb': row[4],
+            'content': row[5],
+            'time_created': row[6],
+            'time_updated': row[7],
+            'is_published': row[8]
+        } for row in rows
+    ]
+    write_log(200, "get_blog_entries()")
+    return jsonify(blog_entries)
 
 @app.route('/api/blogentries/<int:post_id>', methods=['PUT'])
 def update_blog_entry(post_id):
     data = request.get_json()
-    title = data.get('title')
-    subtitle = data.get('subtitle')
-    blurb = data.get('blurb')
-    content = data.get('content')
-    is_published = data.get('is_published', False)
-    time_updated = datetime.now()
-
-    with sqlite3.connect(db_name) as conn:
-        cursor = conn.cursor()
-        cursor.execute('''
-            UPDATE BlogEntry SET title=?, subtitle=?, blurb=?, content=?, time_updated=?, is_published=?
-            WHERE post_id=?
-        ''', (title, subtitle, blurb, content, time_updated, is_published, post_id))
-        conn.commit()
-        if cursor.rowcount:
-            write_log(200, "update_blog_entry({post_id})")
-            return jsonify(post_id=post_id, title=title, subtitle=subtitle, blurb=blurb, content=content, time_updated=time_updated, is_published=is_published), 200
-        else:
-            write_log(404, "update_blog_entry({post_id})")
-            return jsonify(error="Blog entry not found"), 404
+    rowcount, time_updated = db.update_blog_entry(post_id, data.get('title'), data.get('subtitle'), data.get('blurb'), data.get('content'), data.get('is_published', False))
+    if rowcount:
+        write_log(200, f"update_blog_entry({post_id})")
+        return jsonify(post_id=post_id, time_updated=time_updated, **data), 200
+    else:
+        write_log(404, f"update_blog_entry({post_id})")
+        return jsonify(error="Blog entry not found"), 404
 
 @app.route('/api/blogentries/<int:post_id>', methods=['DELETE'])
 def delete_blog_entry(post_id):
-    with sqlite3.connect(db_name) as conn:
-        cursor = conn.cursor()
-        cursor.execute('DELETE FROM BlogEntry WHERE post_id=?', (post_id,))
-        conn.commit()
-        if cursor.rowcount:
-            write_log(200, "delete_blog_entry({post_id})")
-            return jsonify(message="Blog entry deleted"), 200
-        else:
-            write_log(404, "delete_blog_entry({post_id})")
-            return jsonify(error="Blog entry not found"), 404
+    rowcount = db.delete_blog_entry(post_id)
+    if rowcount:
+        write_log(200, f"delete_blog_entry({post_id})")
+        return jsonify(message="Blog entry deleted"), 200
+    else:
+        write_log(404, f"delete_blog_entry({post_id})")
+        return jsonify(error="Blog entry not found"), 404
 
 if __name__ == '__main__':
-    init_db()
     app.run(host='0.0.0.0', port=8080)

--- a/myblogapp/database.py
+++ b/myblogapp/database.py
@@ -1,0 +1,81 @@
+import sqlite3
+from datetime import datetime
+
+db_name = 'myblog.db'
+
+def create_author(username, email, password, bio, profile_picture):
+    try:
+        with sqlite3.connect(db_name) as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                INSERT INTO Author (username, email, password, bio, profile_picture)
+                VALUES (?, ?, ?, ?, ?)
+            ''', (username, email, password, bio, profile_picture))
+            conn.commit()
+            return cursor.lastrowid
+    except sqlite3.IntegrityError:
+        return None
+def get_author(user_id):
+    with sqlite3.connect(db_name) as conn:
+        cursor = conn.cursor()
+        cursor.execute('SELECT * FROM Author WHERE user_id=?', (user_id,))
+        return cursor.fetchone()
+
+def update_author(user_id, username, email, bio, profile_picture):
+    with sqlite3.connect(db_name) as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+            UPDATE Author SET username=?, email=?, bio=?, profile_picture=?
+            WHERE user_id=?
+        ''', (username, email, bio, profile_picture, user_id))
+        conn.commit()
+        return cursor.rowcount
+
+def delete_author(user_id):
+    with sqlite3.connect(db_name) as conn:
+        cursor = conn.cursor()
+        cursor.execute('DELETE FROM Author WHERE user_id=?', (user_id,))
+        conn.commit()
+        return cursor.rowcount
+
+def create_blog_entry(user_id, title, subtitle, blurb, content, is_published):
+    time_created = datetime.now()
+    time_updated = time_created
+    with sqlite3.connect(db_name) as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+            INSERT INTO BlogEntry (user_id, title, subtitle, blurb, content, time_created, time_updated, is_published)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''', (user_id, title, subtitle, blurb, content, time_created, time_updated, is_published))
+        conn.commit()
+        return cursor.lastrowid, time_created
+
+def get_blog_entry(post_id):
+    with sqlite3.connect(db_name) as conn:
+        cursor = conn.cursor()
+        cursor.execute('SELECT * FROM BlogEntry WHERE post_id=?', (post_id,))
+        return cursor.fetchone()
+
+def get_blog_entries():
+    with sqlite3.connect(db_name) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM BlogEntry")
+        return cursor.fetchall()
+
+def update_blog_entry(post_id, title, subtitle, blurb, content, is_published):
+    time_updated = datetime.now()
+    with sqlite3.connect(db_name) as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+            UPDATE BlogEntry SET title=?, subtitle=?, blurb=?, content=?, time_updated=?, is_published=?
+            WHERE post_id=?
+        ''', (title, subtitle, blurb, content, time_updated, is_published, post_id))
+        conn.commit()
+        return cursor.rowcount, time_updated
+
+def delete_blog_entry(post_id):
+    with sqlite3.connect(db_name) as conn:
+        cursor = conn.cursor()
+        cursor.execute('DELETE FROM BlogEntry WHERE post_id=?', (post_id,))
+        conn.commit()
+        return cursor.rowcount


### PR DESCRIPTION
Updated app.py to split out database operations and API calls into separate modules. 

Addresses issue: https://github.com/AeroArty/SDDE330_HW4/issues/2


Items addressed in this PR: 
1. You could put the routes (lines 17 through 194) into a separate Python file. This could be a way to implement the Single Responsibility Principle. This way, you could have your app.py file focus on running the program, while you have another file that just contains the routes.

3. In app.py, is there a reason why you call init_db() on line 197? It doesn’t look to me like you need that line or the init_db function (lines 9 through 11). You could remove that since, with the Interface Segregation Principle in mind, you don’t want your code to depend on things that are not needed.